### PR TITLE
Change URL for student_dist.tar.gz

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,7 +2,7 @@ sudo apt-get install -y flex bison build-essential csh openjdk-6-jdk libxaw7-dev
 sudo mkdir /usr/class
 sudo chown vagrant /usr/class
 cd /usr/class
-wget http://spark-university.s3.amazonaws.com/stanford-compilers/vm/student-dist.tar.gz
+wget https://s3-us-west-1.amazonaws.com/prod-edx/Compilers/Misc/student-dist.tar.gz
 tar -xf student-dist.tar.gz
 ln -s /usr/class/cs143/cool /home/vagrant
 echo "export PATH=/usr/class/cs143/cool/bin:\$PATH" >> /home/vagrant/.bashrc


### PR DESCRIPTION
I updated the URL for `student_dist.tar.gz`, as it has moved to a different location (see here: https://lagunita.stanford.edu/courses/Engineering/Compilers/Fall2014/6b750292e90d4950b895f621a5671b49/). Trying to `wget` the original URL in `bootstrap.sh` causes a 403 error.